### PR TITLE
Harden CI and modernize pnpm toolchain (corepack + pnpm 11)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   run-cdk-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     defaults:
       run:
@@ -23,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - name: Set up devenv cache
-        uses: cachix/cachix-action@v16
+        uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
         with:
           name: devenv
 
@@ -38,7 +39,7 @@ jobs:
         run: nix profile add nixpkgs#devenv
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.ASSUME_ROLE }}
           aws-region: us-west-2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,14 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     defaults:
       run:
@@ -21,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - name: Set up devenv cache
-        uses: cachix/cachix-action@v16
+        uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
         with:
           name: devenv
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -14,7 +14,7 @@
 
   languages.javascript.enable = true;
   languages.javascript.package = pkgs.nodejs_24;
-  languages.javascript.pnpm.enable = true;
+  languages.javascript.corepack.enable = true;
 
   packages = [
     pkgs.rustup # not actually using rustup, but the cdk builder expects it

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "",
+  "packageManager": "pnpm@11.5.2",
   "scripts": {
     "deploy": "pnpm --filter trashcal-cdk run deploy",
     "smoke": "pnpm --filter trashcal-cdk run smoke"


### PR DESCRIPTION
## Summary

Modernizes the toolchain and hardens GitHub Actions workflows, matching the treatment applied to sibling repos.

### pnpm → corepack + pnpm 11
- `devenv.nix`: replaced `languages.javascript.pnpm.enable = true` with `languages.javascript.corepack.enable = true`.
- Root `package.json`: pinned `"packageManager": "pnpm@11.5.2"`.
- Regenerated the lockfile with pnpm 11 (`pnpm install --lockfile-only`); it stays at `lockfileVersion: '9.0'` with no content changes.

### Build allowlist — N/A
`pnpm-workspace.yaml` has no `allowBuilds`/`onlyBuiltDependencies`/`settings` config, and an empirical `CI=true pnpm install --frozen-lockfile` produced no `ERR_PNPM_IGNORED_BUILDS`. Left as-is.

### CI workflow hardening (`deploy.yml`, `rust.yml`)
- Pinned every action to a commit SHA with a `# vX.Y.Z` comment (checkout, install-nix-action, cachix-action, configure-aws-credentials).
- Added `timeout-minutes: 30` to every job.
- Added a standard concurrency group to `rust.yml`. `deploy.yml` keeps its dedicated serialized `deploy` group (`cancel-in-progress: false`).
- `deploy.yml` remains gated to push/main + `workflow_dispatch`, so it is skipped on PRs (expected).

These workflows use the devenv-shell pattern rather than `setup-node`/`pnpm/action-setup`, so the pnpm-store cache reordering items from the playbook do not apply. No Dockerfile and no Vite config exist, so those items are N/A.

### Validation
- `actionlint` passes on both workflows with no warnings.
- `CI=true pnpm install --frozen-lockfile` and `--ignore-scripts` both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)