### PR TITLE
fix(cdk): reference existing GitHub OIDC provider via fromAccount

### DIFF
--- a/cdk/lib/trashcal-cdk-stack.ts
+++ b/cdk/lib/trashcal-cdk-stack.ts
@@ -29,7 +29,12 @@ export class TrashcalCdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: TrashcalCdkStackProps) {
     super(scope, id, props);
 
-    const provider = new GithubActionsIdentityProvider(this, "GithubProvider");
+    // The GitHub OIDC provider is an account-level singleton, created in a
+    // prior deploy. Reference the existing one rather than managing it here.
+    const provider = GithubActionsIdentityProvider.fromAccount(
+      this,
+      "GithubProvider",
+    );
     const uploadRole = new GithubActionsRole(this, "UploadRole", {
       provider: provider,
       owner: "stabbylambda",


### PR DESCRIPTION
aws-cdk-github-oidc v4 switched GithubActionsIdentityProvider from a
Lambda-backed custom resource (Custom::AWSCDKOpenIdConnectProvider) to the
native AWS::IAM::OIDCProvider. Reusing the same logical id across that type
change made CloudFormation reject the change set ("Update of resource type is
not permitted").

The provider is an account-level singleton, so reference the existing one with
fromAccount instead of managing it in this stack. Migration was done in two
deploys: first retaining the v2 custom resource's physical provider, then
removing it here so the retained provider survives and UploadRole's trust
policy points at the existing provider ARN.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
