### PR TITLE
Manage CloudFront access logs with a 90-day lifecycle

### DIFF
--- a/cdk/lib/trashcal-cdk-stack.ts
+++ b/cdk/lib/trashcal-cdk-stack.ts
@@ -19,6 +19,7 @@ import {
 } from "aws-cdk-github-oidc";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as cloudfrontOrigins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as s3 from "aws-cdk-lib/aws-s3";
 
 export interface TrashcalCdkStackProps extends cdk.StackProps {
   domainName: string;
@@ -100,8 +101,30 @@ export class TrashcalCdkStack extends cdk.Stack {
       }
     );
 
+    // CloudFront access logs bucket. Standard (legacy) CloudFront logging
+    // delivers log files using bucket ACLs, so ACLs must stay enabled
+    // (BUCKET_OWNER_PREFERRED) and the bucket can't use SSE-KMS — hence
+    // SSE-S3. The 90-day lifecycle rule caps growth. This replaces the old
+    // out-of-band `trashcal-access-logs` bucket, which can be decommissioned
+    // once this distribution is delivering logs here.
+    const accessLogsBucket = new s3.Bucket(this, "trashcal-access-logs", {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      lifecycleRules: [
+        {
+          id: "expire-access-logs",
+          expiration: cdk.Duration.days(90),
+        },
+      ],
+    });
+
     new cloudfront.Distribution(this, "cloudfront-api", {
       domainNames: [props.domainName],
+      enableLogging: true,
+      logBucket: accessLogsBucket,
+      logFilePrefix: "cloudfront/",
       defaultBehavior: {
         origin: new cloudfrontOrigins.HttpOrigin(
           `${api.apiId}.execute-api.${cdk.Stack.of(this).region}.amazonaws.com`


### PR DESCRIPTION
## Why

S3 storage review showed `trashcal-access-logs` (~25.6 MB, growing ~0.64%/mo) with **no lifecycle policy** — and it wasn't managed by CDK at all. The CloudFront distribution had no logging configured in the stack; the bucket was created out-of-band, so nothing capped its growth.

## What

- Add a **CDK-managed S3 log bucket** with a **90-day expiration** lifecycle rule.
- Configure it for CloudFront standard logging requirements:
  - **ACLs enabled** (`BUCKET_OWNER_PREFERRED`) — CloudFront delivers logs via bucket ACLs; this is the usual silent-failure gotcha.
  - **SSE-S3** encryption (standard logging can't use SSE-KMS), public access blocked, TLS enforced.
- Wire the distribution to log into it via `enableLogging` / `logBucket`, under a `cloudfront/` prefix.

The bucket is CDK-named (auto-generated), so it won't collide with the existing physical `trashcal-access-logs` bucket.

## Follow-up (not in this PR)

After deploy, confirm logs land under the new `cloudfront/` prefix, then **empty and delete the old orphaned `trashcal-access-logs` bucket** manually (needs AWS access).

## Validation

- Project-local `tsc --noEmit` passes clean.
- Full `cdk synth`/deploy not run here (bundles the Rust lambda + needs `DOMAIN_NAME`/`EMAIL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)