### PR TITLE
chore(cdk): silence cross-stack reference warning and drop unused binding

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -67,6 +67,7 @@
     "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
     "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
     "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
-    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false
+    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false,
+    "@aws-cdk/core:defaultCrossStackReferences": "strong"
   }
 }

--- a/cdk/lib/trashcal-cdk-stack.ts
+++ b/cdk/lib/trashcal-cdk-stack.ts
@@ -36,7 +36,7 @@ export class TrashcalCdkStack extends cdk.Stack {
       this,
       "GithubProvider",
     );
-    const uploadRole = new GithubActionsRole(this, "UploadRole", {
+    new GithubActionsRole(this, "UploadRole", {
       provider: provider,
       owner: "stabbylambda",
       repo: "trashcal",


### PR DESCRIPTION
## Summary

Two small CDK hygiene fixes:

- **Silence the cross-stack-reference warning.** Set the `@aws-cdk/core:defaultCrossStackReferences` feature flag explicitly to `"strong"` in `cdk/cdk.json`. CDK was emitting `WARNING No cross-stack-reference strength configured, defaulting to "strong"` on every command. The project's only cross-stack reference is the ACM cert passed from `TrashcalCertStack` (us-east-1) to `TrashcalCdkStack` (us-west-2) — a *cross-region* reference, which CDK implements via SSM parameters + a custom resource rather than CloudFormation exports. So this flag has no behavioral effect here; `"strong"` simply locks in current behavior with zero deploy risk and no migration. (The alternative `"weak"` is AWS's recommended end state but would require a `"both"` → deploy → `"weak"` migration for no practical benefit on this project.)

- **Drop the unused `uploadRole` binding** in `trashcal-cdk-stack.ts`, introduced with the recent CloudFront access-logs change. `GithubActionsRole` registers itself with the stack on construction, so the role is still synthesized into the template — only the dangling variable (a TypeScript `declared but never read` diagnostic) is gone. Matches the file's existing style for other side-effecting constructs.

## Testing

- `cdk synth` exits 0 with no cross-stack-reference warning in stderr.
- `tsc --noEmit` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)