### PR TITLE
ci: cache Rust builds in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,18 @@ jobs:
         shell: bash
         run: nix profile add nixpkgs#devenv
 
+      # The Rust toolchain comes from the Nix rust-overlay, so cargo/rustc are
+      # only on PATH inside `devenv shell`. Expose their bin dir to subsequent
+      # action steps so rust-cache can probe the toolchain for its cache key.
+      - name: Expose Rust toolchain to GitHub PATH
+        run: dirname "$(command -v cargo)" >> "$GITHUB_PATH"
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        with:
+          workspaces: lambda
+          cache-on-failure: true
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,19 @@ jobs:
         shell: bash
         run: nix profile add nixpkgs#devenv
 
+      # The Rust toolchain comes from the Nix rust-overlay, so cargo/rustc are
+      # only on PATH inside `devenv shell`. Expose their bin dir to subsequent
+      # action steps so rust-cache can probe the toolchain for its cache key.
+      - name: Expose Rust toolchain to GitHub PATH
+        run: dirname "$(command -v cargo)" >> "$GITHUB_PATH"
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        with:
+          workspaces: lambda
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Build
         run: cd lambda && cargo lambda build --arm64
 


### PR DESCRIPTION
## Problem

Both workflows recompile all **~277 Rust crate dependencies from scratch on every run** — there is no Rust caching today.

Measured on recent runs:

| Workflow | Rust compile cost |
|---|---|
| `rust.yml` | `Build` 128s + `Run tests` 55s = **~3 min** |
| `deploy.yml` | the release `zigbuild` inside `CDK deploy` (166s total) |

## Change

Add [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) (pinned to the `v2.9.1` SHA, matching the repo's action-pinning convention) to both workflows. It caches `~/.cargo` plus the dependency artifacts under `lambda/target`, so on a cache hit only our own crates recompile.

**Nix wrinkle:** the toolchain comes from the `rust-overlay`, not rustup, so `cargo`/`rustc` are only on `PATH` inside `devenv shell`. A one-line PATH-bridge step (`dirname "$(command -v cargo)" >> "$GITHUB_PATH"`) exposes their bin dir to the action-level steps the cache action runs. Verified the Nix binaries run standalone (RPATH is self-contained).

Config notes:
- `workspaces: lambda` — points the cache at `lambda/Cargo.lock` / `lambda/target`.
- `cache-on-failure: true` — a failing test still saves the compiled-dependency cache.
- `save-if: github.ref == 'refs/heads/main'` (CI only) — PRs **restore** main's cache but don't each write their own, keeping the shared cache warm without churning GitHub's 10 GB/repo cache quota. `deploy.yml` only runs on main, so it always saves.

## Expected impact

After the first main-branch run populates the cache, dependency compilation is skipped:
- `rust.yml`: the ~3 min of compile should drop to roughly **30–60s**.
- `deploy.yml`: the release-build portion of `CDK deploy` shrinks similarly.

Caches invalidate automatically when `lambda/Cargo.lock` or the toolchain version changes — i.e. exactly when a full rebuild is actually needed. `rust-cache` prunes the local crates' artifacts and keeps only dependency outputs, so the cache stays well under the local 2 GB `target/` size.

> Note: the first run on `main` after merge will be full-cost (it writes the cache); PRs benefit once main has a cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)