### PR TITLE
ci(cdk): add monthly CDK garbage collection workflow

### DIFF
--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -1,0 +1,73 @@
+name: CDK Garbage Collect
+on:
+  # First of each month at 07:00 UTC. Also runnable on demand.
+  schedule:
+    - cron: "0 7 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+# Share the deploy concurrency group so gc never runs while a deploy is in
+# flight -- AWS warns against garbage collecting during an active deployment.
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  run-cdk-gc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: devenv shell bash -- -e {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+
+      - name: Set up devenv cache
+        uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: devenv
+
+      - name: Install devenv
+        shell: bash
+        run: nix profile add nixpkgs#devenv
+
+      - name: Configure AWS Credentials
+        id: creds
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.ASSUME_ROLE }}
+          aws-region: us-west-2
+          role-duration-seconds: 900
+
+      - name: Install deps
+        run: cd cdk && pnpm install
+
+      # Garbage collect unused S3 assets in both bootstrapped environments:
+      # us-west-2 hosts the Lambda, us-east-1 hosts the CloudFront cert and the
+      # cross-region-reference custom resources. Explicit environments mean gc
+      # works off deployed CloudFormation templates without synthesizing the
+      # app (no Rust build needed). Assets are tagged when first found isolated
+      # and only deleted after sitting unused for the rollback buffer, so a
+      # recent deploy can still roll back.
+      - name: CDK garbage collect
+        env:
+          DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+          EMAIL: ${{ secrets.EMAIL }}
+        run: >
+          cd cdk && pnpm exec cdk gc
+          "aws://${{ steps.creds.outputs.aws-account-id }}/us-west-2"
+          "aws://${{ steps.creds.outputs.aws-account-id }}/us-east-1"
+          --unstable=gc
+          --type=s3
+          --rollback-buffer-days=30
+          --created-buffer-days=1
+          --confirm=false


### PR DESCRIPTION
## What

Adds `.github/workflows/gc.yml` — a scheduled (1st of each month, 07:00 UTC) and on-demand (`workflow_dispatch`) workflow that runs `cdk gc` to reclaim unused S3 assets from the CDK bootstrap buckets.

It targets **both** bootstrapped environments:
- `us-west-2` — the Lambda asset zips
- `us-east-1` — the CloudFront certificate stack and the `crossRegionReferences` custom-resource Lambdas

## Why

Every deploy uploads a new asset to the bootstrap bucket; CDK never cleans up the old ones. `cdk gc` (GA-track, still behind `--unstable=gc`) reclaims them. A monthly scheduled job is the standard hands-off pattern and is decoupled from the deploy path so it can't slow or race a deployment.

## Design notes

- **No new IAM permissions.** The existing OIDC `UploadRole` only grants `sts:AssumeRole` on `cdk-*`, which is the same mechanism `cdk deploy` uses; gc assumes those bootstrap roles to do the S3 work. The wildcard covers both regions.
- **No synth / no Rust build.** Explicit `aws://account/region` targets make gc work off deployed CloudFormation templates, so the job doesn't synthesize the app (account ID comes from the credentials step output).
- **Safe deletion.** `--rollback-buffer-days=30` tags assets when first seen unused and only deletes them after 30 days, keeping recent deploys rollback-able; `--created-buffer-days=1` never touches assets younger than a day.
- **No overlap with deploys.** Shares `concurrency.group: deploy`.
- `--type=s3` only (no ECR assets in this project; also avoids a known gc-on-ECR hang).

## Prerequisite to verify

gc's tagging needs object-tag permissions on the bootstrap file-publishing role, added in a newer bootstrap template. Check the version:

\`\`\`bash
aws ssm get-parameter --name /cdk-bootstrap/hnb659fds/version --region us-west-2 --query Parameter.Value --output text
aws ssm get-parameter --name /cdk-bootstrap/hnb659fds/version --region us-east-1 --query Parameter.Value --output text
\`\`\`

If gc fails with AccessDenied on `PutObjectTagging`, refresh once with the current CLI: `cdk bootstrap aws://ACCOUNT/us-west-2 aws://ACCOUNT/us-east-1`.

## Testing

Trigger manually via **Actions → CDK Garbage Collect → Run workflow** and watch the log. For a pure preview on the first run, temporarily add `--action=print` to the gc step (lists candidates without tagging or deleting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)